### PR TITLE
doc: Adds ToTemp to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [Zim](https://github.com/zimfw/zimfw)                                         | Shell                | [site](https://zimfw.sh)                                            |
 | [Potigol](https://github.com/potigol/potigol)                                 | Scala                |                                                                     |
 | [Kotlin4noobs](https://github.com/gustavofreze/kotlin4noobs)                  | Kotlin               |                                                                     |
+| [ToTemp](https://github.com/eddyyxxyy/ToTemp)                                 | Python               | [Pypi](https://pypi.org/project/totemp/)                            |
 | [Kamu](https://github.com/ayr-ton/kamu)                                       | Python               |                                                                     |
 | [Lespy](https://github.com/natanfeitosa/lespy)                                | Python               | [Pypi](https://pypi.org/project/Lespy/)                             |
 | [fklearn](https://github.com/nubank/fklearn)                                  | Python               |                                                                     |


### PR DESCRIPTION
ToTemp é uma API distribuída como um pacote Python que provê representações dinâmicas de temperaturas, usando orientação à objetos.

Se for trabalhar com escalas de temperatura, procure automatizar seus cálculos, conversões e representações das escalas com as Classes do ToTemp.

A documentação do projeto te dará um tutorial de instalação e sugestões de uso, além de explicar os objetos que podem ser criados com as Classes (em inglês).

Doc: [Read The Docs](https://totemp.readthedocs.io/en/latest/)