### PR TITLE
add duzerulinux-os in opensource-br

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [AtomicReact](https://github.com/AtomicReact/AtomicReact)                                    | Javascript           | [documentação](https://atomicreact.js.org)                                                                          |
 | [Funny algorithms](https://github.com/ReciHub/FunnyAlgorithms)                               | Múltiplas linguagens |
 | [Board](https://github.com/lucasnuic/board)                                                  | Múltiplas linguagens |
+| [DuzeruLinux](https://github.com/duzerulinux)                                                | Múltiplas linguagens | 
 
 <div id='license'></div>
 


### PR DESCRIPTION
Adiconei o link da comunidade da distro linux "duzerulinux" que é mantida, desenvolvida e feita por desenvolvedores brasileiros. Esse projeto é de código aberto e é bem interessante.