### PR TITLE
add delegua

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [Concurrently](https://github.com/open-cli-tools/concurrently)                               | TypeScript           | [npm](https://www.npmjs.com/package/concurrently)                                                                   |
 | [Poku - Simplificando Testes Automatizados](https://github.com/wellwelwel/poku)              | TypeScript           | [documentação](https://poku.io/docs)                                                                                |
 | [AtomicReact](https://github.com/AtomicReact/AtomicReact)                                    | Javascript           | [documentação](https://atomicreact.js.org)                                                                          |
+| [Delegua](https://github.com/DesignLiquido/delegua)                                          | TypeScript           |
 | [Funny algorithms](https://github.com/ReciHub/FunnyAlgorithms)                               | Múltiplas linguagens |
 | [BigLinux](https://github.com/biglinux)                                                      | Múltiplas linguagens | 
 | [DuzeruLinux](https://github.com/duzerulinux)                                                | Múltiplas linguagens | 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [Comunidades tech](https://github.com/impulsoteam/comunidadestech)                           | Javascript           | [site](https://comunidades.tech)                                                                                    |
 | [English Talking API](https://github.com/barbosamaatheus/english-talking-api)                | Javascript           | [discord](https://discord.gg/XTrKQ8w)                                                                               |
 | [Mesh](https://github.com/ionited/mesh)                                                      | Javascript           | [npm](https://www.npmjs.com/package/@ionited/mesh)                                                                  |
+| [AtomicReact](https://github.com/AtomicReact/AtomicReact)                                    | Javascript           | [documentação](https://atomicreact.js.org)                                                                          |
 | [Bot WhatsApp](https://github.com/caioagiani/whatsapp-bot)                                   | TypeScript           |                                                                                                                     |
 | [Concurrently](https://github.com/open-cli-tools/concurrently)                               | TypeScript           | [npm](https://www.npmjs.com/package/concurrently)                                                                   |
-| [Poku - Simplificando Testes Automatizados](https://github.com/wellwelwel/poku)              | TypeScript           | [documentação](https://poku.io/docs)                                                                                |
-| [AtomicReact](https://github.com/AtomicReact/AtomicReact)                                    | Javascript           | [documentação](https://atomicreact.js.org)                                                                          |
 | [Delegua](https://github.com/DesignLiquido/delegua)                                          | TypeScript           |
+| [Poku - Simplificando Testes Automatizados](https://github.com/wellwelwel/poku)              | TypeScript           | [documentação](https://poku.io/docs)                                                                                |
 | [Funny algorithms](https://github.com/ReciHub/FunnyAlgorithms)                               | Múltiplas linguagens |
 | [BigLinux](https://github.com/biglinux)                                                      | Múltiplas linguagens | 
 | [DuzeruLinux](https://github.com/duzerulinux)                                                | Múltiplas linguagens | 


### PR DESCRIPTION
Outra linguagem de programação feita no brasil, e que pode ser utilizada em algum backend. delegua é uma linguagem de programação para o ensino de informática é diferente do visualg. o visual g é ensino de programação, e o delugua é para pessoas que tem dificuldade em inglês, então é feita em ptbr. no entanto, gera o código em js/typescript. o visualg pode gerar código em outras linguagens, só que é restrito pela quantidade de recurso oferecido
ou suportado. no caso do delugua não gera código em várias linguagens, mas tem muito suporte do js/typescript. O visualg nasceu como alternativa ao portugol, que era o "visualg" de portugal.