### PR TITLE
brasilopen

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [Funny algorithms](https://github.com/ReciHub/FunnyAlgorithms)                                   | Múltiplas linguagens |                                                                     |
 | [BigLinux](https://github.com/biglinux)                                                          | Múltiplas linguagens |                                                                     |
 | [DuzeruLinux](https://github.com/duzerulinux)                                                    | Múltiplas linguagens |                                                                     |
+| [BrasilOpen](https://github.com/brasilopen/brasilopen)                                           | Múltiplas linguagens |
 
 <div id='license'></div>
 


### PR DESCRIPTION
BrasilOpen é um projeto para reunir dados abertos sobre várias coisas.  Acharia legal caso queiram e se interessem em adicioná-lo aqui. Espero que gostem desse projeto aberto.