### PR TITLE
adicionar SOS-RS

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [Concurrently](https://github.com/open-cli-tools/concurrently)                                   | TypeScript           | [npm](https://www.npmjs.com/package/concurrently)                   |
 | [Delegua](https://github.com/DesignLiquido/delegua)                                              | TypeScript           |                                                                     |
 | [Poku - Simplificando Testes Automatizados](https://github.com/wellwelwel/poku)                  | TypeScript           | [documentação](https://poku.io/docs)                                |
+| [SOS-RS](https://github.com/SOS-RS/backend)                                                      | Typesript |
 | [Funny algorithms](https://github.com/ReciHub/FunnyAlgorithms)                                   | Múltiplas linguagens |                                                                     |
 | [BigLinux](https://github.com/biglinux)                                                          | Múltiplas linguagens |                                                                     |
 | [DuzeruLinux](https://github.com/duzerulinux)                                                    | Múltiplas linguagens |                                                                     |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [Concurrently](https://github.com/open-cli-tools/concurrently)                                   | TypeScript           | [npm](https://www.npmjs.com/package/concurrently)                   |
 | [Delegua](https://github.com/DesignLiquido/delegua)                                              | TypeScript           |                                                                     |
 | [Poku - Simplificando Testes Automatizados](https://github.com/wellwelwel/poku)                  | TypeScript           | [documentação](https://poku.io/docs)                                |
-| [SOS-RS](https://github.com/SOS-RS/backend)                                                      | Typesript |
+| [SOS-RS](https://github.com/SOS-RS/backend)                                                      | Typesript | [site](https://sos-rs.com/) [projeto](https://github.com/SOS-RS)
 | [Funny algorithms](https://github.com/ReciHub/FunnyAlgorithms)                                   | Múltiplas linguagens |                                                                     |
 | [BigLinux](https://github.com/biglinux)                                                          | Múltiplas linguagens |                                                                     |
 | [DuzeruLinux](https://github.com/duzerulinux)                                                    | Múltiplas linguagens |                                                                     |


### PR DESCRIPTION
#### Introdução
Globo, G1: *"O [Rio Grande do Sul](https://g1.globo.com/rs/rio-grande-do-sul/) vive uma de suas piores tragédias climáticas. A chuva que persiste há pelo menos uma semana colocou o estado inteiro em situação de calamidade e deve continuar pelos próximos dias, causando mais estragos. O [número de mortos já chega a 32](https://g1.globo.com/rs/rio-grande-do-sul/noticia/2024/05/02/temporal-no-rs-mortes-0205-noite.ghtml) e dezenas de pessoas estão desaparecidas em meio às cheias. Os meteorologistas explicam que a catástrofe é resultado de pelo menos três fenômenos que afetam a região e foram agravados pelas mudanças no clima. E a tendência é de piora por conta da previsão de mais chuva."*

#### pergunta/contexto | contexto/pergunta
O que isso tem haver com esse repositório?
- Esse repositório é espaço para divulgação de projetos open-source brasileiros. Podemos adicionar o backend do projeto SOS-RS?  
- mas o que é o projeto SOS-RS? é um projeto de código aberto para ajudar o RS com a enchente.  se ajudarmos com a divulgação, talvez mais desenvolvedores ajudem e podem se interessar em ajudar.