### PR TITLE
pix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [Pirata](https://github.com/piratas/gti)                                                         | Markdown             | [site](https://partidopirata.org/) [comunidade](https://github.com/piratas) |
 | [Lista Maravilhosa Open Source](https://github.com/camilatigre/listamaravilhosaopensource)       | Markdown             |                                                                     |
 | [Caravela HackerClub](https://github.com/caravelahc/projetos)                                    | Markdown             | [site](https://caravela.ufsc.br/) [comunidade](https://github.com/caravelahc/) |
+| [PIX](https://github.com/bacen/pix-api)                                                          | Markdown             | [site](https://www.bcb.gov.br/) [comunidade](https://github.com/bacen) |
 | [Docz](https://github.com/doczjs/docz)                                                           | Javascript           | [site](https://www.docz.site)                                       |
 | [Dialetus](https://github.com/dialetus/dialetus-service)                                         | Javascript           |                                                                     |
 | [Brasil API](https://github.com/BrasilAPI/BrasilAPI)                                             | Javascript           | [site](https://brasilapi.com.br)                                    |


### PR DESCRIPTION
Grupo oficial do Banco Central do Brasil para debater sobre o PIX de forma aberta. site para devs de backend, frontend, engenharia e afins.